### PR TITLE
Upgrade axum

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-axum = "0.2.3"
+axum = "0.3"
 serde = { version = "1.0", features = ["derive"] }
 rmp-serde = "0.15"
 hyper = "0.14"


### PR DESCRIPTION
Axum released 0.3. This PR updates the dependency on Axum to the latest version.