### PR TITLE
Remove Axum default features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ license = "MIT"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-axum = "0.7"
+axum = { version = "0.7", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 rmp-serde = "1.1"
 hyper = "1.1"
@@ -16,4 +16,5 @@ mime = "0.3"
 
 [dev-dependencies]
 futures-util = "0.3"
-tokio = { version = "1.35", features = ["full"]}
+tokio = { version = "1.35", features = ["full"] }
+axum = { version = "0.7" }


### PR DESCRIPTION
This crate unnecessarily brings in the Axum default features which don't build on the platform I was targeting (wasm). The crate builds fine and passes all the test cases without them. 