### PR TITLE
feat: update to Axum 8

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "axum-msgpack"
-version = "0.4.0"
+version = "0.5.0"
 edition = "2021"
 description = "serialize/derserialize msgpack for axum"
 license = "MIT"
@@ -8,13 +8,13 @@ license = "MIT"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-axum = { version = "0.7", default-features = false }
+axum = { version = "0.8", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
-rmp-serde = "1.1"
-hyper = "1.1"
+rmp-serde = "1.3"
+hyper = "1.5"
 mime = "0.3"
 
 [dev-dependencies]
 futures-util = "0.3"
-tokio = { version = "1.35", features = ["full"] }
-axum = { version = "0.7" }
+tokio = { version = "1.42", features = ["full"] }
+axum = { version = "0.8" }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,7 +6,6 @@ use axum::{
     extract::{FromRequest, Request},
     response::{IntoResponse, Response},
     http::{header::HeaderValue, StatusCode},
-    async_trait,
 };
 use hyper::header;
 use rejection::MsgPackRejection;
@@ -93,7 +92,6 @@ mod rejection;
 #[derive(Debug, Clone, Copy, Default)]
 pub struct MsgPack<T>(pub T);
 
-#[async_trait]
 impl<T, S> FromRequest<S> for MsgPack<T>
 where
     T: DeserializeOwned,
@@ -234,7 +232,6 @@ where
 #[derive(Debug, Clone, Copy, Default)]
 pub struct MsgPackRaw<T>(pub T);
 
-#[async_trait]
 impl<T, S> FromRequest<S> for MsgPackRaw<T>
 where
     T: DeserializeOwned,
@@ -245,7 +242,7 @@ where
     async fn from_request(req: Request, state: &S) -> Result<Self, Self::Rejection> {
         if !message_pack_content_type(&req) {
             return Err(MissingMsgPackContentType.into())
-        } 
+        }
         let bytes = Bytes::from_request(req, state).await?;
         let value = rmp_serde::from_slice(&bytes).map_err(InvalidMsgPackBody::from_err)?;
         Ok(MsgPackRaw(value))
@@ -365,7 +362,7 @@ mod tests {
 
         assert_eq!(serialized, bytes);
     }
-    
+
     #[tokio::test]
     async fn deserializes_named() {
         let input = Input { foo: "bar".into() };
@@ -375,10 +372,10 @@ mod tests {
             header::CONTENT_TYPE,
             HeaderValue::from_static("application/msgpack"),
         );
-        
+
         let outcome =
             <MsgPack<Input> as FromRequest<_, _>>::from_request(request, &||{}).await;
-        
+
         let outcome = outcome.unwrap();
         assert_eq!(input, outcome.0);
     }
@@ -409,7 +406,7 @@ mod tests {
         let outcome =
             <MsgPackRaw<Input> as FromRequest<_, _>>::from_request(request, &||{})
                 .await;
-        
+
         let outcome = outcome.unwrap();
         assert_eq!(input, outcome.0);
     }


### PR DESCRIPTION
Hey, recently Axum has released a new version. This is an MR to make the needed changes to update for this.

 * Updates the code base to use Axum 8.
 * Drop use of async_trait.
 * Update dependencies to the latest.
